### PR TITLE
Add alt attributes to images

### DIFF
--- a/additional-projects.html
+++ b/additional-projects.html
@@ -23,7 +23,7 @@
                 <div class="row">
 
                     <div class="column-50">
-                        <img src="https://harkitecture-media.s3.us-east-1.amazonaws.com/personal-projects/box+cut+and+crease+linework/composite-lw-1.svg">
+                        <img src="https://harkitecture-media.s3.us-east-1.amazonaws.com/personal-projects/box+cut+and+crease+linework/composite-lw-1.svg" alt="Cut and crease linework">
                     </div>
     
                     <div class="column-50">
@@ -61,7 +61,7 @@
                 <div class="row">
 
                     <div class="column-50">
-                        <img src="https://harkitecture-media.s3.us-east-1.amazonaws.com/personal-projects/notebook+press/notebook-press-model.png">
+                        <img src="https://harkitecture-media.s3.us-east-1.amazonaws.com/personal-projects/notebook+press/notebook-press-model.png" alt="Notebook press model">
                     </div>
     
                     <div class="column-50">

--- a/alexandria-plugin.html
+++ b/alexandria-plugin.html
@@ -37,12 +37,12 @@
                 
                 <div class="column-50">
                     <h4>Before Alexandria</h4>
-                    <img src="https://harkitecture-alexandria.s3.us-east-1.amazonaws.com/media-active/alexandria-general/images/other/before-alexandria.png">
+                    <img src="https://harkitecture-alexandria.s3.us-east-1.amazonaws.com/media-active/alexandria-general/images/other/before-alexandria.png" alt="Before Alexandria screenshot">
                 </div>
 
                 <div class="column-50">
                     <h4>After Alexandria</h4>
-                    <img src="https://harkitecture-alexandria.s3.us-east-1.amazonaws.com/media-active/alexandria-general/images/other/after-alexandria.png">
+                    <img src="https://harkitecture-alexandria.s3.us-east-1.amazonaws.com/media-active/alexandria-general/images/other/after-alexandria.png" alt="After Alexandria screenshot">
                 </div>
 
             </div>

--- a/case-studies.html
+++ b/case-studies.html
@@ -28,7 +28,7 @@
             <hr>
 
               <a href="case-study-1.html">
-                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/case-studies/exterior-1b.png" class="home-images" id="home-images-1a">
+                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/case-studies/exterior-1b.png" class="home-images" id="home-images-1a" alt="Facade study">
               </a>
 
               <h3>
@@ -50,7 +50,7 @@
             <hr>
 
             <a href="case-studies.html">
-                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/web-general/placeholders/image-placeholders-01.png" class="home-images" id="home-images-2a">
+                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/web-general/placeholders/image-placeholders-01.png" class="home-images" id="home-images-2a" alt="Placeholder image">
             </a>
 
             <h3>

--- a/case-study-1.html
+++ b/case-study-1.html
@@ -24,8 +24,7 @@
 
                 <div class="column-60">
 
-                    <img
-                        src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/case-studies/exterior-1b.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/case-studies/exterior-1b.png" alt="Facade perspective">
 
                 </div>
 
@@ -58,8 +57,7 @@
             <div class="row">
 
                 <div class="column-75">
-                    <img
-                        src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/case-studies/exterior-1a.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/case-studies/exterior-1a.png" alt="Perforated panel facade">
                 </div>
 
                 <div class="column-25">

--- a/collingsworth-marketplace.html
+++ b/collingsworth-marketplace.html
@@ -24,7 +24,7 @@
 
                 <div class="column-60">
 
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-07.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-07.png" alt="Collingsworth Marketplace render">
 
                 </div>
 
@@ -79,10 +79,8 @@
             <div class="row">
 
                 <div class="column-75">
-                    <img
-                    src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-01.png">
-                    <img
-                    src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-02.png"> 
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-01.png" alt="Collingsworth rendering 1">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-02.png" alt="Collingsworth rendering 2">
                 </div>
 
                 <div class="column-25">
@@ -104,8 +102,7 @@
             <div class="row">
 
                 <div class="column-75">
-                    <img
-                    src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-06.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-06.png" alt="Collingsworth section diagram">
                 </div>
 
                 <div class="column-25">
@@ -128,8 +125,7 @@
             <div class="row">
 
                 <div class="column-75">
-                    <img
-                    src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-03.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-03.png" alt="Collingsworth adaptive reuse">
                 </div>
 
                 <div class="column-25">
@@ -144,10 +140,8 @@
             <div class="row">
 
                 <div class="column-75">
-                    <img
-                    src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-04.png">
-                    <img
-                    src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-05.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-04.png" alt="Collingsworth environmental 1">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Collingsworth-Market/Collingsworth-05.png" alt="Collingsworth environmental 2">
                 </div>
 
                 <div class="column-25">

--- a/dead-mall-fall.html
+++ b/dead-mall-fall.html
@@ -24,7 +24,7 @@
 
                 <div class="column-60">
 
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Dead-Mall-Fall/Dead-Mall-Fall-07.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Dead-Mall-Fall/Dead-Mall-Fall-07.png" alt="Dead Mall Fall aerial view">
 
                 </div>
 
@@ -81,8 +81,7 @@
             <div class="row">
 
                 <div class="column-75">
-                    <img
-                        src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Dead-Mall-Fall/Dead-Mall-Fall-01.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Dead-Mall-Fall/Dead-Mall-Fall-01.png" alt="Boulevard redesign rendering">
                 </div>
 
                 <div class="column-25">
@@ -101,8 +100,7 @@
             <div class="row">
 
                 <div class="column-75">
-                    <img
-                        src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Dead-Mall-Fall/Dead-Mall-Fall-02.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Dead-Mall-Fall/Dead-Mall-Fall-02.png" alt="Commercial avenues rendering">
                 </div>
 
                 <div class="column-25">
@@ -122,8 +120,7 @@
             <div class="row">
 
                 <div class="column-75">
-                    <img
-                        src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Dead-Mall-Fall/Dead-Mall-Fall-03.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Dead-Mall-Fall/Dead-Mall-Fall-03.png" alt="Residential streets rendering">
                 </div>
 
                 <div class="column-25">
@@ -139,8 +136,7 @@
             <div class="row">
 
                 <div class="column-75">
-                    <img
-                        src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Dead-Mall-Fall/Dead-Mall-Fall-04.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Dead-Mall-Fall/Dead-Mall-Fall-04.png" alt="Trails and footpaths rendering">
                 </div>
 
                 <div class="column-25">
@@ -165,8 +161,7 @@
 
             <div class="row">
                 <div class="column-75">
-                    <img
-                        src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Dead-Mall-Fall/Dead-Mall-Fall-05.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Dead-Mall-Fall/Dead-Mall-Fall-05.png" alt="Wayfinding signage rendering">
                 </div>
 
                 <div class="column-25">

--- a/felipe-portfolio.html
+++ b/felipe-portfolio.html
@@ -26,7 +26,7 @@
                     <hr>
 
                     <a href="living-outside-the-box.html">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/LOTB-Cover-01.png" class="home-images" id="home-images-1a">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/LOTB-Cover-01.png" class="home-images" id="home-images-1a" alt="Living Outside the Box cover">
                     </a>
                     <h3>
                         <a href="living-outside-the-box.html" class="no-ul" id="link-1a">
@@ -37,7 +37,7 @@
                     <p>Modular housing inspired by Safdie's Habitat 67 located in Rio De Janeiro, Brazil</p>
 
                     <a href="collingsworth-marketplace.html">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/Collingsworth-Cover-01.png" class="home-images" id="home-images-1a">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/Collingsworth-Cover-01.png" class="home-images" id="home-images-1a" alt="Collingsworth Marketplace cover">
                     </a>
                     <h3>
                         <a href="collingsworth-marketplace.html" class="no-ul" id="link-1a">
@@ -48,7 +48,7 @@
                     <p>Mixed-use development in Houston, TX</p>
 
                     <a href="dead-mall-fall.html">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/Dead-Mall-Fall-Cover-01.png" class="home-images" id="home-images-1a">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/Dead-Mall-Fall-Cover-01.png" class="home-images" id="home-images-1a" alt="Dead Mall Fall cover">
                     </a>
                     <h3>
                         <a href="dead-mall-fall.html" class="no-ul" id="link-1a">
@@ -67,7 +67,7 @@
                     <hr>
 
                     <a href="alexandria-plugin.html">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/Alex-Cover-01.png" class="home-images" id="home-images-2a">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/Alex-Cover-01.png" class="home-images" id="home-images-2a" alt="Alexandria plugin cover">
                     </a>
                     <h3>
                         <a href="alexandria-plugin.html" class="no-ul" id="link-2a">
@@ -78,7 +78,7 @@
                     <p>Custom-built tool for parametric design workflows</p>
 
                     <a href="portfolio.html">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-02.png" class="home-images" id="home-images-2a">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-02.png" class="home-images" id="home-images-2a" alt="Parametric example linework">
                     </a>
                     <h3>
                         <a href="portfolio.html" class="no-ul" id="link-2a">
@@ -89,7 +89,7 @@
                     <p>Experiments with Alexandria</p>
 
                     <a href="case-studies.html">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/case-studies/exterior-1b.png" class="home-images" id="home-images-2a">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/case-studies/exterior-1b.png" class="home-images" id="home-images-2a" alt="Case study exterior view">
                     </a>
                     <h3>
                         <a href="case-studies.html" class="no-ul" id="link-2a">

--- a/gh-sample-1.html
+++ b/gh-sample-1.html
@@ -21,7 +21,7 @@
       <div class="row">
 
         <div class="column-60">
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-01.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-01.png" alt="Linework example 1">
         </div>
 
         <div class="column-40">
@@ -33,7 +33,7 @@
           <br>
           <br>
 
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/square-patt-gh.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/square-patt-gh.png" alt="Grasshopper square pattern">
 
           <h3>Downloads</h3>
           <hr>

--- a/gh-sample-2.html
+++ b/gh-sample-2.html
@@ -21,7 +21,7 @@
       <div class="row">
 
         <div class="column-60">
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-02.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-02.png" alt="Linework example 2">
         </div>
 
         <div class="column-35">
@@ -33,7 +33,7 @@
           <br>
           <br>
 
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/hex-patt-gh.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/hex-patt-gh.png" alt="Grasshopper hex pattern">
 
           <h3>Downloads</h3>
           <hr>

--- a/gh-sample-3.html
+++ b/gh-sample-3.html
@@ -21,7 +21,7 @@
       <div class="row">
 
         <div class="column-60">
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-03.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-03.png" alt="Linework example 3">
         </div>
 
         <div class="column-40">
@@ -33,7 +33,7 @@
           <br>
           <br>
 
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/tri-patt-gh.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/tri-patt-gh.png" alt="Grasshopper triangle pattern">
 
           <h3>Downloads</h3>
           <hr>

--- a/gh-sample-4.html
+++ b/gh-sample-4.html
@@ -21,7 +21,7 @@
       <div class="row">
 
         <div class="column-60">
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-06.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-06.png" alt="Linework example 6">
         </div>
 
         <div class="column-40">
@@ -33,7 +33,7 @@
           <br>
           <br>
 
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/voronoi-gh.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/voronoi-gh.png" alt="Grasshopper voronoi pattern">
 
           <h3>Downloads</h3>
           <hr>

--- a/gh-sample-6.html
+++ b/gh-sample-6.html
@@ -21,7 +21,7 @@
       <div class="row">
 
         <div class="column-60">
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-07.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-07.png" alt="Linework example 7">
         </div>
 
         <div class="column-40">
@@ -33,7 +33,7 @@
           <br>
           <br>
 
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/rotated-patt-gh.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/rotated-patt-gh.png" alt="Grasshopper rotated pattern">
 
           <h3>Downloads</h3>
           <hr>

--- a/gh-sample-7.html
+++ b/gh-sample-7.html
@@ -21,7 +21,7 @@
       <div class="row">
 
         <div class="column-60">
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-08.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-08.png" alt="Linework example 8">
         </div>
 
         <div class="column-40">
@@ -33,7 +33,7 @@
           <br>
           <br>
 
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/culled-patt-gh.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/culled-patt-gh.png" alt="Grasshopper culled pattern">
 
           <h3>Downloads</h3>
           <hr>

--- a/gh-sample-8.html
+++ b/gh-sample-8.html
@@ -21,7 +21,7 @@
       <div class="row">
 
         <div class="column-60">
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-04.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-04.png" alt="Linework example 4">
         </div>
 
         <div class="column-40">
@@ -33,7 +33,7 @@
           <br>
           <br>
 
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/extruded-array-gh.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/extruded-array-gh.png" alt="Grasshopper extruded array">
 
           <h3>Downloads</h3>
           <hr>

--- a/gh-sample-9.html
+++ b/gh-sample-9.html
@@ -21,7 +21,7 @@
       <div class="row">
 
         <div class="column-60">
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-05.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-05.png" alt="Linework example 5">
         </div>
 
         <div class="column-40">
@@ -33,7 +33,7 @@
           <br>
           <br>
 
-          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/extruded-wave-gh.png">
+          <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/grasshopper-defs/extruded-wave-gh.png" alt="Grasshopper extruded wave">
 
           <h3>Downloads</h3>
           <hr>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
                     <hr>
 
                     <a href="living-outside-the-box.html">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/LOTB-Cover-01.png" class="home-images" id="home-images-1a">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/LOTB-Cover-01.png" class="home-images" id="home-images-1a" alt="Living Outside the Box cover">
                     </a>
                     <h3>
                         <a href="living-outside-the-box.html" class="no-ul" id="link-1a">
@@ -37,7 +37,7 @@
                     <p>Modular housing inspired by Safdie's Habitat 67 located in Rio De Janeiro, Brazil</p>
 
                     <a href="collingsworth-marketplace.html">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/Collingsworth-Cover-01.png" class="home-images" id="home-images-1a">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/Collingsworth-Cover-01.png" class="home-images" id="home-images-1a" alt="Collingsworth Marketplace cover">
                     </a>
                     <h3>
                         <a href="collingsworth-marketplace.html" class="no-ul" id="link-1a">
@@ -48,7 +48,7 @@
                     <p>Mixed-use development in Houston, TX</p>
 
                     <a href="dead-mall-fall.html">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/Dead-Mall-Fall-Cover-01.png" class="home-images" id="home-images-1a">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/Dead-Mall-Fall-Cover-01.png" class="home-images" id="home-images-1a" alt="Dead Mall Fall cover">
                     </a>
                     <h3>
                         <a href="dead-mall-fall.html" class="no-ul" id="link-1a">
@@ -67,7 +67,7 @@
                     <hr>
 
                     <a href="alexandria-plugin.html">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/Alex-Cover-01.png" class="home-images" id="home-images-2a">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Portfolio-Cover-Images/Alex-Cover-01.png" class="home-images" id="home-images-2a" alt="Alexandria plugin cover">
                     </a>
                     <h3>
                         <a href="alexandria-plugin.html" class="no-ul" id="link-2a">
@@ -78,7 +78,7 @@
                     <p>Custom-built tool for parametric design workflows</p>
 
                     <a href="portfolio.html">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-02.png" class="home-images" id="home-images-2a">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-02.png" class="home-images" id="home-images-2a" alt="Parametric example">
                     </a>
                     <h3>
                         <a href="portfolio.html" class="no-ul" id="link-2a">
@@ -89,7 +89,7 @@
                     <p>Experiments with Alexandria</p>
 
                     <a href="case-studies.html">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/case-studies/exterior-1b.png" class="home-images" id="home-images-2a">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/case-studies/exterior-1b.png" class="home-images" id="home-images-2a" alt="Case studies exterior">
                     </a>
                     <h3>
                         <a href="case-studies.html" class="no-ul" id="link-2a">

--- a/install-alexandria.html
+++ b/install-alexandria.html
@@ -46,8 +46,7 @@
                 </div>
     
                 <div class="column-50">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/download-install/RH-Start-Page.png"
-                    alt="Rhino Start Page">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/download-install/RH-Start-Page.png" alt="Rhino Start Page">
                 </div>
             </div>
             
@@ -64,8 +63,7 @@
                 </div>
     
                 <div class="column-50">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/download-install/GH-start-page.png"
-                    alt="Rhino Start Page">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/download-install/GH-start-page.png" alt="Rhino Start Page">
                 </div>
             </div>
             

--- a/living-outside-the-box.html
+++ b/living-outside-the-box.html
@@ -23,7 +23,7 @@
             <div class="row">
 
                 <div class="column-60">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-13.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-13.png" alt="Concept diagram">
                 </div>
 
                 <div class="column-40">
@@ -71,7 +71,7 @@
             <div class="row">
 
                 <div class="column-75">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-02.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-02.png" alt="Rio mountains context">
                 </div>
 
                 <div class="column-25">
@@ -86,7 +86,7 @@
             <div class="row">
 
                 <div class="column-75">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-01.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-01.png" alt="Project plan view">
                 </div>
 
                 <div class="column-25">
@@ -107,7 +107,7 @@
 
             <div class="row">
                 <div class="column-75">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-03.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-03.png" alt="Box module diagram">
 
                 </div>
 
@@ -129,7 +129,7 @@
 
             <div class="row">
                 <div class="column-75">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-04.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-04.png" alt="Housing unit types">
                 </div>
 
                 <div class="column-25">
@@ -143,7 +143,7 @@
 
             <div class="row">
                 <div class="column-75">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-05.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-05.png" alt="Structural diagram">
                 </div>
 
                 <div class="column-25">
@@ -164,8 +164,8 @@
 
             <div class="row">
                 <div class="column-75">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-06.png">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-07.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-06.png" alt="Cluster rendering 1">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-07.png" alt="Cluster rendering 2">
                 </div>
 
                 <div class="column-25">
@@ -186,8 +186,8 @@
 
             <div class="row">
                 <div class="column-75">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-08.png">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-09.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-08.png" alt="Interior perspective 1">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-09.png" alt="Interior perspective 2">
                 </div>
 
                 <div class="column-25">
@@ -208,9 +208,9 @@
 
             <div class="row">
                 <div class="column-75">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-11.png">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-12.png">
-                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-10.png">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-11.png" alt="Community rendering 1">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-12.png" alt="Community rendering 2">
+                    <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/harkitecture-general/portfolio/Living-Outside-the-Box/LOTS-10.png" alt="Community rendering 3">
                 </div>
 
                 <div class="column-25">

--- a/portfolio.html
+++ b/portfolio.html
@@ -28,7 +28,7 @@
             <hr>
 
               <a href="gh-sample-1.html">
-                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-01.png" class="home-images" id="home-images-1a">
+                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-01.png" class="home-images" id="home-images-1a" alt="Parametric example 1">
               </a>
 
               <h3>
@@ -40,7 +40,7 @@
               <p>Patterns built based on a rectangular grid system</p>
 
               <a href="gh-sample-2.html">
-                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-02.png" class="home-images" id="home-images-1a">
+                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-02.png" class="home-images" id="home-images-1a" alt="Parametric example 2">
               </a>
     
               <h3>
@@ -53,7 +53,7 @@
 
 
               <a href="gh-sample-3.html">
-                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-03.png" class="home-images" id="home-images-1a">
+                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-03.png" class="home-images" id="home-images-1a" alt="Parametric example 3">
               </a>
     
               <h3>
@@ -66,7 +66,7 @@
 
 
               <a href="gh-sample-4.html">
-                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-06.png" class="home-images" id="home-images-1a">
+                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-06.png" class="home-images" id="home-images-1a" alt="Parametric example 6">
               </a>
     
               <h3>
@@ -87,7 +87,7 @@
             <hr>
 
             <a href="gh-sample-8.html">
-                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-04.png" class="home-images" id="home-images-2a">
+                <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-04.png" class="home-images" id="home-images-2a" alt="Linework example 4">
               </a>
   
             <h3>
@@ -100,7 +100,7 @@
 
 
             <a href="gh-sample-9.html">
-              <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-05.png" class="home-images" id="home-images-2a">
+              <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-05.png" class="home-images" id="home-images-2a" alt="Linework example 5">
             </a>
   
             <h3>
@@ -112,7 +112,7 @@
             <p>Lofting surfaces from curves created parametrically</p>
 
             <a href="gh-sample-6.html">
-              <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-07.png" class="home-images" id="home-images-3a">
+              <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-07.png" class="home-images" id="home-images-3a" alt="Parametric example 7">
             </a>
   
             <h3>
@@ -124,7 +124,7 @@
             <p>Rotating geometries based on an attractor</p>
 
             <a href="gh-sample-7.html">
-              <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-08.png" class="home-images" id="home-images-3a">
+              <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/example-files/images/linework/example-c-08.png" class="home-images" id="home-images-3a" alt="Parametric example 8">
             </a>
   
             <h3>

--- a/use-alexandria.html
+++ b/use-alexandria.html
@@ -45,7 +45,7 @@
 
                 <div class="row">
                     <div class="column-35">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/bg-1.png">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/bg-1.png" alt="Grasshopper background">
                     </div>
 
                     <div class="column-35">
@@ -90,7 +90,7 @@
                 <div class="row">
 
                     <div class="column-35">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/cb-1.png">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/cb-1.png" alt="Component connection 1">
                     </div>
                     
                     <div class="column-35">
@@ -109,7 +109,7 @@
                 <div class="row">
 
                     <div class="column-35">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/cb-2.png">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/cb-2.png" alt="Component connection 2">
                     </div>
 
                     <div class="column-35">
@@ -127,7 +127,7 @@
 
                 <div class="row">
                     <div class="column-35">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/cb-3.png">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/cb-3.png" alt="Component connection 3">
                     </div>
 
                     <div class="column-35">
@@ -154,7 +154,7 @@
                 <div class="row">
 
                     <div class="column-35">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/gg-1.png">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/gg-1.png" alt="Geometry generation step 1">
                     </div>
 
                     <div class="column-35">
@@ -173,7 +173,7 @@
                 <div class="row">
 
                     <div class="column-35">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/gg-2.png">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/gg-2.png" alt="Geometry generation step 2">
                     </div>
 
                     <div class="column-35">
@@ -206,7 +206,7 @@
                 <div class="row">
 
                     <div class="column-35">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/2d-1.png">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/2d-1.png" alt="2D pattern step 1">
                     </div>
                     
                     <div class="column-35">
@@ -224,7 +224,7 @@
                 <div class="row">
 
                     <div class="column-35">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/2d-2.png">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/2d-2.png" alt="2D pattern step 2">
                     </div>
                     
                     <div class="column-35">
@@ -242,7 +242,7 @@
                 <div class="row">
 
                     <div class="column-35">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/2d-3.png">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/2d-3.png" alt="2D pattern step 3">
                     </div>
                     
                     <div class="column-35">
@@ -269,7 +269,7 @@
                 <div class="row">
 
                     <div class="column-35">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/3d-1.png">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/3d-1.png" alt="3D model step 1">
                     </div>
                     
                     <div class="column-35">
@@ -286,7 +286,7 @@
                 <div class="row">
 
                     <div class="column-35">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/3d-2.png">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/3d-2.png" alt="3D model step 2">
                     </div>
                     
                     <div class="column-35">
@@ -319,7 +319,7 @@
                 <div class="row">
 
                     <div class="column-35">
-                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/uo-1.png">
+                        <img src="https://harkitecture-3.s3.us-east-1.amazonaws.com/media/alexandria-general/images/getting-started/uo-1.png" alt="Using output in Rhino">
                     </div>
                     
                     <div class="column-35">


### PR DESCRIPTION
## Summary
- add alt text to images in HTML files
- ensure all `<img>` tags include concise descriptions

## Testing
- `grep -n "<img" -r --exclude-dir=.git | grep -v "alt="`

------
https://chatgpt.com/codex/tasks/task_e_684b3b2963cc832abc4bbdf0dd3095ef